### PR TITLE
Reloop mixage addition

### DIFF
--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -137,7 +137,7 @@
       <!-- T6_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key></key>
+        <key>pregain</key>
         <status>0xB0</status>
         <midino>0x72</midino>
         <options>
@@ -149,6 +149,15 @@
         <group>[Channel1]</group>
         <key>rate</key>
         <status>0xE0</status>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T7_SHIFT = Pitch Fader -->
+      <control>
+        <group>[Channel1]</group>
+        <key>rate</key>
+        <status>0xE2</status>
         <options>
           <normal />
         </options>
@@ -485,8 +494,8 @@
       </control>
       <!-- T22_SHIFT = ? -->
       <control>
-        <group>[Channel1]</group>
-        <key></key>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>parameter3</key>
         <status>0xB0</status>
         <midino>0x74</midino>
         <options>
@@ -505,8 +514,8 @@
       </control>
       <!-- T23_SHIFT = ? -->
       <control>
-        <group>[Channel1]</group>
-        <key></key>
+       <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>parameter2</key>
         <status>0xB0</status>
         <midino>0x75</midino>
         <options>
@@ -525,8 +534,8 @@
       </control>
       <!-- T24_SHIFT = ? -->
       <control>
-        <group>[Channel1]</group>
-        <key></key>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>parameter1</key>
         <status>0xB0</status>
         <midino>0x76</midino>
         <options>
@@ -566,7 +575,7 @@
       <!-- T26_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key></key>
+        <key>volume</key>
         <status>0xB0</status>
         <midino>0x77</midino>
         <options>
@@ -696,7 +705,7 @@
       <!-- T6_SHIFT = ? -->
       <control>
         <group>[Channel2]</group>
-        <key></key>
+        <key>pregain</key>
         <status>0xB0</status>
         <midino>0x78</midino>
         <options>
@@ -708,6 +717,15 @@
         <group>[Channel2]</group>
         <key>rate</key>
         <status>0xE1</status>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T7_SHIFT = Pitch Fader -->
+      <control>
+        <group>[Channel2]</group>
+        <key>rate</key>
+        <status>0xE3</status>
         <options>
           <normal />
         </options>
@@ -1044,8 +1062,8 @@
       </control>
       <!-- T22_SHIFT = ? -->
       <control>
-        <group>[Channel2]</group>
-        <key></key>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>parameter3</key>
         <status>0xB0</status>
         <midino>0x7A</midino>
         <options>
@@ -1064,8 +1082,8 @@
       </control>
       <!-- T23_SHIFT = ? -->
       <control>
-        <group>[Channel2]</group>
-        <key></key>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>parameter2</key>
         <status>0xB0</status>
         <midino>0x7B</midino>
         <options>
@@ -1084,8 +1102,8 @@
       </control>
       <!-- T24_SHIFT = ? -->
       <control>
-        <group>[Channel2]</group>
-        <key></key>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>parameter1</key>
         <status>0xB0</status>
         <midino>0x7C</midino>
         <options>
@@ -1125,7 +1143,7 @@
       <!-- T26_SHIFT = ? -->
       <control>
         <group>[Channel2]</group>
-        <key></key>
+        <key>volume</key>
         <status>0xB0</status>
         <midino>0x7D</midino>
         <options>

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -1222,6 +1222,34 @@
         <midino>0x02</midino>
         <minimum>0.5</minimum>
       </output>
+      <output>
+        <group>[Channel2]</group>
+        <key>beats_translate_earlier</key>
+        <status>0x90</status>
+        <midino>0x0F</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[Channel2]</group>
+        <key>beats_translate_later</key>
+        <status>0x90</status>
+        <midino>0x10</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[Channel2]</group>
+        <key>rate_temp_down</key>
+        <status>0x90</status>
+        <midino>0x0F</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[Channel2]</group>
+        <key>rate_temp_up</key>
+        <status>0x90</status>
+        <midino>0x10</midino>
+        <minimum>0.5</minimum>
+      </output>
     </outputs>
   </controller>
 </MixxxControllerPreset>

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.1+">
+<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.4+">
   <info>
     <name>Reloop Mixage</name>
-    <author>HorstBaerbel / gqzomer</author>
-    <description>Mapping for the Reloop Mixage Interface Edition controller (https://www.reloop.com/reloop-mixage-ie). Should also work on the non-interface version.</description>
+    <author>HorstBaerbel &amp; gqzomer</author>
+    <description>Mapping for the Reloop Mixage Interface Edition MK1, Interface Edition MK2 and Controller Edition.</description>
     <forums>https://mixxx.discourse.group/t/reloop-mixage-mapping/14779</forums>
     <wiki>https://github.com/mixxxdj/mixxx/wiki/Reloop%20Mixage</wiki>
-    <manual>https://www.reloop.com/media/catalog/product/pdf/2/2/4/224964_Reloop_IM.pdf</manual>
+    <manual>reloop_mixage</manual>
   </info>
   <controller id="Reloop Mixage">
     <scriptfiles>
       <file functionprefix="Mixage" filename="Reloop-Mixage.scripts.js" />
     </scriptfiles>
     <!-- The comments reference the buttons on the controller The T prefixes are taken from the controller overview of the manual -->
+    <!-- link to the manual from reloop https://www.reloop.com/media/catalog/product/pdf/2/2/4/224964_Reloop_IM.pdf -->
     <controls>
       <!-- T1 = Pitch Bend Minus Button -->
       <control>
@@ -195,7 +196,7 @@
       <!-- T9_SHIFT = Master Deck Assignment -->
       <control>
         <group>[Channel1]</group>
-        <key>sync_master</key>
+        <key>sync_leader</key>
         <status>0x90</status>
         <midino>0x46</midino>
         <options>
@@ -214,12 +215,12 @@
       </control>
       <!-- T10_TURN_SHIFT = Pan Balance Dial -->
       <control>
-        <group>[Channel1]</group>
-        <key>Mixage.handlePan</key>
+        <group>[QuickEffectRack1_[Channel1]]</group>
+        <key>chain_preset_selector</key>
         <status>0xB0</status>
         <midino>0x60</midino>
         <options>
-          <script-binding />
+          <SelectKnob />
         </options>
       </control>
       <!-- T10_PRESS = ? -->
@@ -234,8 +235,8 @@
       </control>
       <!-- T10_PRESS_SHIFT = ? -->
       <control>
-        <group>[Channel1]</group>
-        <key></key>
+        <group>[QuickEffectRack1_[Channel1]]</group>
+        <key>enabled</key>
         <status>0x90</status>
         <midino>0x60</midino>
         <options>
@@ -445,11 +446,11 @@
       <!-- T19 = Play/Pause -->
       <control>
         <group>[Channel1]</group>
-        <key>play</key>
+        <key>Mixage.handlePlay</key>
         <status>0x90</status>
         <midino>0x0C</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T19_SHIFT = Cue 4 -->
@@ -763,7 +764,7 @@
       <!-- T9_SHIFT = Master Deck Assignment -->
       <control>
         <group>[Channel2]</group>
-        <key>sync_master</key>
+        <key>sync_leader</key>
         <status>0x90</status>
         <midino>0x54</midino>
         <options>
@@ -782,12 +783,12 @@
       </control>
       <!-- T10_TURN_SHIFT = Pan Balance Dial -->
       <control>
-        <group>[Channel2]</group>
-        <key>Mixage.handlePan</key>
+        <group>[QuickEffectRack1_[Channel2]]</group>
+        <key>chain_preset_selector</key>
         <status>0xB0</status>
         <midino>0x62</midino>
         <options>
-          <script-binding />
+          <SelectKnob />
         </options>
       </control>
       <!-- T10_PRESS = ? -->
@@ -802,8 +803,8 @@
       </control>
       <!-- T10_PRESS_SHIFT = ? -->
       <control>
-        <group>[Channel2]</group>
-        <key></key>
+        <group>[QuickEffectRack1_[Channel2]]</group>
+        <key>enabled</key>
         <status>0x90</status>
         <midino>0x62</midino>
         <options>
@@ -1013,11 +1014,11 @@
       <!-- T19 = Play/Pause -->
       <control>
         <group>[Channel2]</group>
-        <key>play</key>
+        <key>Mixage.handlePlay</key>
         <status>0x90</status>
         <midino>0x1A</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T19_SHIFT = Cue 4 -->

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -28,7 +28,7 @@
       <!-- T1_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_earlier</key>
+        <key>pitch_down</key>
         <status>0x90</status>
         <midino>0x40</midino>
         <options>
@@ -48,7 +48,7 @@
       <!-- T2_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_later</key>
+        <key>pitch_up</key>
         <status>0x90</status>
         <midino>0x41</midino>
         <options>
@@ -596,7 +596,7 @@
       <!-- T1_SHIFT = ? -->
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_earlier</key>
+        <key>pitch_down</key>
         <status>0x90</status>
         <midino>0x4E</midino>
         <options>
@@ -616,7 +616,7 @@
       <!-- T2_SHIFT = ? -->
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_later</key>
+        <key>pitch_up</key>
         <status>0x90</status>
         <midino>0x4F</midino>
         <options>
@@ -1215,14 +1215,14 @@
     <outputs>
       <output>
         <group>[Channel1]</group>
-        <key>beats_translate_earlier</key>
+        <key>pitch_down</key>
         <status>0x90</status>
         <midino>0x01</midino>
         <minimum>0.5</minimum>
       </output>
       <output>
         <group>[Channel1]</group>
-        <key>beats_translate_later</key>
+        <key>pitch_up</key>
         <status>0x90</status>
         <midino>0x02</midino>
         <minimum>0.5</minimum>
@@ -1243,14 +1243,14 @@
       </output>
       <output>
         <group>[Channel2]</group>
-        <key>beats_translate_earlier</key>
+        <key>pitch_down</key>
         <status>0x90</status>
         <midino>0x0F</midino>
         <minimum>0.5</minimum>
       </output>
       <output>
         <group>[Channel2]</group>
-        <key>beats_translate_later</key>
+        <key>pitch_up</key>
         <status>0x90</status>
         <midino>0x10</midino>
         <minimum>0.5</minimum>

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -832,12 +832,12 @@
       </control>
       <!-- T12 = FX On Button -->
       <control>
-        <group>[EffectRack1_EffectUnit2]</group>
-        <key>group_[Channel2]_enable</key>
+        <group>[Channel2]</group>
+        <key>Mixage.handleFxPress</key>
         <status>0x90</status>
         <midino>0x16</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T12_SHIFT = Keylock Button -->
@@ -1192,62 +1192,6 @@
       </control>
     </controls>
     <outputs>
-      <output>
-        <group>[EffectRack1_EffectUnit1]</group>
-        <key>group_[Channel1]_enable</key>
-        <status>0x90</status>
-        <midino>0x08</midino>
-        <minimum>0.5</minimum>
-      </output>
-      <output>
-        <group>[EffectRack1_EffectUnit2]</group>
-        <key>group_[Channel1]_enable</key>
-        <status>0x90</status>
-        <midino>0x08</midino>
-        <minimum>0.5</minimum>
-      </output>
-      <output>
-        <group>[EffectRack1_EffectUnit3]</group>
-        <key>group_[Channel1]_enable</key>
-        <status>0x90</status>
-        <midino>0x08</midino>
-        <minimum>0.5</minimum>
-      </output>
-      <output>
-        <group>[EffectRack1_EffectUnit4]</group>
-        <key>group_[Channel1]_enable</key>
-        <status>0x90</status>
-        <midino>0x08</midino>
-        <minimum>0.5</minimum>
-      </output>
-      <output>
-        <group>[EffectRack1_EffectUnit1]</group>
-        <key>group_[Channel2]_enable</key>
-        <status>0x90</status>
-        <midino>0x16</midino>
-        <minimum>0.5</minimum>
-      </output>
-      <output>
-        <group>[EffectRack1_EffectUnit2]</group>
-        <key>group_[Channel2]_enable</key>
-        <status>0x90</status>
-        <midino>0x16</midino>
-        <minimum>0.5</minimum>
-      </output>
-      <output>
-        <group>[EffectRack1_EffectUnit3]</group>
-        <key>group_[Channel2]_enable</key>
-        <status>0x90</status>
-        <midino>0x16</midino>
-        <minimum>0.5</minimum>
-      </output>
-      <output>
-        <group>[EffectRack1_EffectUnit4]</group>
-        <key>group_[Channel2]_enable</key>
-        <status>0x90</status>
-        <midino>0x16</midino>
-        <minimum>0.5</minimum>
-      </output>
       <output>
         <group>[Channel1]</group>
         <key>beats_translate_earlier</key>

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -67,11 +67,11 @@
       <!-- T4 = Autoloop -->
       <control>
         <group>[Channel1]</group>
-        <key>beatloop_activate</key>
+        <key>Mixage.handleLoop</key>
         <status>0x90</status>
         <midino>0x05</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T4_SHIFT = Loop in -->
@@ -107,7 +107,7 @@
       <!-- T5_PRESS = Activate/Deactivate Loop -->
       <control>
         <group>[Channel1]</group>
-        <key>Mixage.handleBeatMovePressed</key>
+        <key>Mixage.handleLoopLengthPress</key>
         <status>0x90</status>
         <midino>0x20</midino>
         <options>
@@ -117,7 +117,7 @@
       <!-- T5_PRESS_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key>Mixage.clearLoop</key>
+        <key>Mixage.handleBeatLoopPress</key>
         <status>0x90</status>
         <midino>0x5F</midino>
         <options>
@@ -165,11 +165,11 @@
       <!-- T8 = Reloop -->
       <control>
         <group>[Channel1]</group>
-        <key>reloop_toggle</key>
+        <key>Mixage.handleReloop</key>
         <status>0x90</status>
         <midino>0x06</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T8_SHIFT = Loop Out -->
@@ -635,11 +635,11 @@
       <!-- T4 = Autoloop -->
       <control>
         <group>[Channel2]</group>
-        <key>beatloop_activate</key>
+        <key>Mixage.handleLoop</key>
         <status>0x90</status>
         <midino>0x13</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T4_SHIFT = Loop in -->
@@ -675,7 +675,7 @@
       <!-- T5_PRESS = ? -->
       <control>
         <group>[Channel2]</group>
-        <key>Mixage.handleBeatMovePressed</key>
+        <key>Mixage.handleLoopLengthPress</key>
         <status>0x90</status>
         <midino>0x22</midino>
         <options>
@@ -685,11 +685,11 @@
       <!-- T5_PRESS_SHIFT = Activate/Deactivate Loop -->
       <control>
         <group>[Channel2]</group>
-        <key></key>
+        <key>Mixage.handleBeatLoopPress</key>
         <status>0x90</status>
         <midino>0x61</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T6 = Gain Dial -->
@@ -733,11 +733,11 @@
       <!-- T8 = Reloop -->
       <control>
         <group>[Channel2]</group>
-        <key>reloop_toggle</key>
+        <key>Mixage.handleReloop</key>
         <status>0x90</status>
         <midino>0x14</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T8_SHIFT = Loop Out -->

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -2,15 +2,17 @@
 <MixxxControllerPreset schemaVersion="1" mixxxVersion="2.1+">
   <info>
     <name>Reloop Mixage</name>
-    <author>Gersom Zomer</author>
+    <author>HorstBaerbel / gqzomer</author>
     <description>Mapping for the Reloop Mixage Interface Edition controller (https://www.reloop.com/reloop-mixage-ie). Should also work on the non-interface version.</description>
     <forums>https://mixxx.discourse.group/t/reloop-mixage-mapping/14779</forums>
     <wiki>https://github.com/mixxxdj/mixxx/wiki/Reloop%20Mixage</wiki>
+    <manual>https://www.reloop.com/media/catalog/product/pdf/2/2/4/224964_Reloop_IM.pdf</manual>
   </info>
   <controller id="Reloop Mixage">
     <scriptfiles>
       <file functionprefix="Mixage" filename="Reloop-Mixage.scripts.js" />
     </scriptfiles>
+    <!-- The comments reference the buttons on the controller The T prefixes are taken from the controller overview of the manual -->
     <controls>
       <!-- T1 = Pitch Bend Minus Button -->
       <control>

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -77,11 +77,11 @@
       <!-- T4_SHIFT = Loop in -->
       <control>
         <group>[Channel1]</group>
-        <key>loop_in</key>
+        <key>Mixage.handleLoopIn</key>
         <status>0x90</status>
         <midino>0x44</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T5_TURN = Loop Length -->
@@ -117,11 +117,11 @@
       <!-- T5_PRESS_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key></key>
+        <key>Mixage.clearLoop</key>
         <status>0x90</status>
         <midino>0x5F</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T6 = Gain Dial -->
@@ -175,11 +175,11 @@
       <!-- T8_SHIFT = Loop Out -->
       <control>
         <group>[Channel1]</group>
-        <key>loop_out</key>
+        <key>Mixage.handleLoopOut</key>
         <status>0x90</status>
         <midino>0x45</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T9 = FX Select Button -->
@@ -645,11 +645,11 @@
       <!-- T4_SHIFT = Loop in -->
       <control>
         <group>[Channel2]</group>
-        <key>loop_in</key>
+        <key>Mixage.handleLoopIn</key>
         <status>0x90</status>
         <midino>0x52</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T5_TURN = Loop Length -->
@@ -743,11 +743,11 @@
       <!-- T8_SHIFT = Loop Out -->
       <control>
         <group>[Channel2]</group>
-        <key>loop_out</key>
+        <key>Mixage.handleLoopOut</key>
         <status>0x90</status>
         <midino>0x53</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <!-- T9 = FX Select Button -->

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -1173,8 +1173,8 @@
       </control>
       <!-- T20_TURN = Trax Encoder -->
       <control>
-        <group>[Library]</group>
-        <key>Mixage.handleTraxTurn</key>
+        <group>[Playlist]</group>
+        <key>Mixage.selectTrack</key>
         <status>0xB0</status>
         <midino>0x1F</midino>
         <options>
@@ -1183,8 +1183,8 @@
       </control>
       <!-- T20_TURN_SHIFT = Folder Navigation -->
       <control>
-        <group>[Library]</group>
-        <key>Mixage.handleTraxTurn</key>
+        <group>[Playlist]</group>
+        <key>Mixage.selectPlaylist</key>
         <status>0xB0</status>
         <midino>0x5E</midino>
         <options>

--- a/res/controllers/Reloop-Mixage.midi.xml
+++ b/res/controllers/Reloop-Mixage.midi.xml
@@ -2,7 +2,7 @@
 <MixxxControllerPreset schemaVersion="1" mixxxVersion="2.1+">
   <info>
     <name>Reloop Mixage</name>
-    <author>HorstBaerbel</author>
+    <author>Gersom Zomer</author>
     <description>Mapping for the Reloop Mixage Interface Edition controller (https://www.reloop.com/reloop-mixage-ie). Should also work on the non-interface version.</description>
     <forums>https://mixxx.discourse.group/t/reloop-mixage-mapping/14779</forums>
     <wiki>https://github.com/mixxxdj/mixxx/wiki/Reloop%20Mixage</wiki>
@@ -12,69 +12,7 @@
       <file functionprefix="Mixage" filename="Reloop-Mixage.scripts.js" />
     </scriptfiles>
     <controls>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.wheelTurn</key>
-        <status>0xB0</status>
-        <midino>0x25</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>cue_play</key>
-        <status>0x90</status>
-        <midino>0x0A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>sync_enabled</key>
-        <status>0x90</status>
-        <midino>0x09</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>cue_default</key>
-        <status>0x90</status>
-        <midino>0x0B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>sync_enabled</key>
-        <status>0x90</status>
-        <midino>0x17</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>cue_default</key>
-        <status>0x90</status>
-        <midino>0x19</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>cue_play</key>
-        <status>0x90</status>
-        <midino>0x18</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
+      <!-- T1 = Pitch Bend Minus Button -->
       <control>
         <group>[Channel1]</group>
         <key>rate_temp_down</key>
@@ -84,438 +22,17 @@
           <normal />
         </options>
       </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>rate_temp_up</key>
-        <status>0x90</status>
-        <midino>0x10</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Master]</group>
-        <key>crossfader</key>
-        <status>0xB0</status>
-        <midino>0x31</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>keylock</key>
-        <status>0x90</status>
-        <midino>0x55</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
+      <!-- T1_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key>Mixage.wheelTurn</key>
-        <status>0xB0</status>
-        <midino>0x24</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>keylock</key>
+        <key>beats_translate_earlier</key>
         <status>0x90</status>
-        <midino>0x47</midino>
+        <midino>0x40</midino>
         <options>
           <normal />
         </options>
       </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>pfl</key>
-        <status>0x90</status>
-        <midino>0x1C</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>Mixage.handleDeckSyncMode</key>
-        <status>0x90</status>
-        <midino>0x46</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.handleDeckSyncMode</key>
-        <status>0x90</status>
-        <midino>0x54</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit1]</group>
-        <key>Mixage.handleEffectChannelOn</key>
-        <status>0x90</status>
-        <midino>0x08</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit2]</group>
-        <key>Mixage.handleEffectChannelOn</key>
-        <status>0x90</status>
-        <midino>0x16</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit1]</group>
-        <key>Mixage.handleEffectChannelSelect</key>
-        <status>0x90</status>
-        <midino>0x07</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit2]</group>
-        <key>Mixage.handleEffectChannelSelect</key>
-        <status>0x90</status>
-        <midino>0x15</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit1]</group>
-        <key>Mixage.handleEffectDryWet</key>
-        <status>0xB0</status>
-        <midino>0x21</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit2]</group>
-        <key>Mixage.handleEffectDryWet</key>
-        <status>0xB0</status>
-        <midino>0x23</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit1]</group>
-        <key>Mixage.handleDryWetPressed</key>
-        <status>0x90</status>
-        <midino>0x21</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EffectRack1_EffectUnit2]</group>
-        <key>Mixage.handleDryWetPressed</key>
-        <status>0x90</status>
-        <midino>0x23</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>Mixage.handlePan</key>
-        <status>0xB0</status>
-        <midino>0x60</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.handlePan</key>
-        <status>0xB0</status>
-        <midino>0x62</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>parameter1</key>
-        <status>0xB0</status>
-        <midino>0x37</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>parameter2</key>
-        <status>0xB0</status>
-        <midino>0x36</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>parameter3</key>
-        <status>0xB0</status>
-        <midino>0x35</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>parameter1</key>
-        <status>0xB0</status>
-        <midino>0x3D</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>parameter2</key>
-        <status>0xB0</status>
-        <midino>0x3C</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>parameter3</key>
-        <status>0xB0</status>
-        <midino>0x3B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[QuickEffectRack1_[Channel1]]</group>
-        <key>super1</key>
-        <status>0xB0</status>
-        <midino>0x34</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[QuickEffectRack1_[Channel2]]</group>
-        <key>super1</key>
-        <status>0xB0</status>
-        <midino>0x3A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>play</key>
-        <status>0x90</status>
-        <midino>0x0C</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>Mixage.scrollToggle</key>
-        <status>0x90</status>
-        <midino>0x03</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.scrollToggle</key>
-        <status>0x90</status>
-        <midino>0x11</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>Mixage.scratchToggle</key>
-        <status>0x90</status>
-        <midino>0x04</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.scratchToggle</key>
-        <status>0x90</status>
-        <midino>0x12</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>loop_in</key>
-        <status>0x90</status>
-        <midino>0x44</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>loop_out</key>
-        <status>0x90</status>
-        <midino>0x45</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>beatloop_activate</key>
-        <status>0x90</status>
-        <midino>0x05</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>reloop_toggle</key>
-        <status>0x90</status>
-        <midino>0x06</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>Mixage.handleBeatMove</key>
-        <status>0xB0</status>
-        <midino>0x5F</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>Mixage.handleBeatMoveLength</key>
-        <status>0xB0</status>
-        <midino>0x20</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>Mixage.handleBeatMovePressed</key>
-        <status>0x90</status>
-        <midino>0x20</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>loop_in</key>
-        <status>0x90</status>
-        <midino>0x52</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>loop_out</key>
-        <status>0x90</status>
-        <midino>0x53</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>beatloop_activate</key>
-        <status>0x90</status>
-        <midino>0x13</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>reloop_toggle</key>
-        <status>0x90</status>
-        <midino>0x14</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.handleBeatMoveLength</key>
-        <status>0xB0</status>
-        <midino>0x22</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.handleBeatMove</key>
-        <status>0xB0</status>
-        <midino>0x61</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.handleBeatMovePressed</key>
-        <status>0x90</status>
-        <midino>0x22</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>Mixage.wheelTouch</key>
-        <status>0x90</status>
-        <midino>0x25</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>pregain</key>
-        <status>0xB0</status>
-        <midino>0x33</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>rate_temp_down</key>
-        <status>0x90</status>
-        <midino>0x0F</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
+      <!-- T2 = Pitch Bend Plus Button -->
       <control>
         <group>[Channel1]</group>
         <key>rate_temp_up</key>
@@ -525,15 +42,296 @@
           <normal />
         </options>
       </control>
+      <!-- T2_SHIFT = ? -->
       <control>
-        <group>[Channel2]</group>
-        <key>pregain</key>
-        <status>0xB0</status>
-        <midino>0x39</midino>
+        <group>[Channel1]</group>
+        <key>beats_translate_later</key>
+        <status>0x90</status>
+        <midino>0x41</midino>
         <options>
           <normal />
         </options>
       </control>
+      <!-- T3 = Shift Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleShift</key>
+        <status>0x90</status>
+        <midino>0x2A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T4 = Autoloop -->
+      <control>
+        <group>[Channel1]</group>
+        <key>beatloop_activate</key>
+        <status>0x90</status>
+        <midino>0x05</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T4_SHIFT = Loop in -->
+      <control>
+        <group>[Channel1]</group>
+        <key>loop_in</key>
+        <status>0x90</status>
+        <midino>0x44</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T5_TURN = Loop Length -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleLoopLength</key>
+        <status>0xB0</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T5_TURN_SHIFT = Beat Move -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleBeatMove</key>
+        <status>0xB0</status>
+        <midino>0x5F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T5_PRESS = Activate/Deactivate Loop -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleBeatMovePressed</key>
+        <status>0x90</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T5_PRESS_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x5F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T6 = Gain Dial -->
+      <control>
+        <group>[Channel1]</group>
+        <key>pregain</key>
+        <status>0xB0</status>
+        <midino>0x33</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T6_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x72</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T7 = Pitch Fader -->
+      <control>
+        <group>[Channel1]</group>
+        <key>rate</key>
+        <status>0xE0</status>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T8 = Reloop -->
+      <control>
+        <group>[Channel1]</group>
+        <key>reloop_toggle</key>
+        <status>0x90</status>
+        <midino>0x06</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T8_SHIFT = Loop Out -->
+      <control>
+        <group>[Channel1]</group>
+        <key>loop_out</key>
+        <status>0x90</status>
+        <midino>0x45</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T9 = FX Select Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.nextEffect</key>
+        <status>0x90</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T9_SHIFT = Master Deck Assignment -->
+      <control>
+        <group>[Channel1]</group>
+        <key>sync_master</key>
+        <status>0x90</status>
+        <midino>0x46</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T10_TURN = FX Dry/Wet Dial -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleEffectDryWet</key>
+        <status>0xB0</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T10_TURN_SHIFT = Pan Balance Dial -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handlePan</key>
+        <status>0xB0</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T10_PRESS = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleDryWetPressed</key>
+        <status>0x90</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T10_PRESS_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x60</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T11_TURN = FX Amount Dail -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleFxAmount</key>
+        <status>0xB0</status>
+        <midino>0x34</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T11_TURN_SHIFT = Filter Dial -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleFilter</key>
+        <status>0xB0</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T11_CENTER = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x34</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T11_CENTER_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x73</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T12 = FX On Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleFxPress</key>
+        <status>0x90</status>
+        <midino>0x08</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T12_SHIFT = Keylock Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>keylock</key>
+        <status>0x90</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T13 = Search Mode Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.scrollToggle</key>
+        <status>0x90</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T13_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.scrollToggle</key>
+        <status>0x90</status>
+        <midino>0x42</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T14 = Scratch Mode Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.scratchToggle</key>
+        <status>0x90</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T14_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.scratchToggle</key>
+        <status>0x90</status>
+        <midino>0x43</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T15_PRESS = Jog Wheel -->
       <control>
         <group>[Channel1]</group>
         <key>Mixage.wheelTouch</key>
@@ -543,157 +341,47 @@
           <script-binding />
         </options>
       </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0x90</status>
-        <midino>0x0D</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0x90</status>
-        <midino>0x1B</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0x90</status>
-        <midino>0x4C</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0x90</status>
-        <midino>0x5A</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0x90</status>
-        <midino>0x1F</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0x90</status>
-        <midino>0x5E</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0xB0</status>
-        <midino>0x1F</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Library]</group>
-        <key>Mixage.handleLibrary</key>
-        <status>0xB0</status>
-        <midino>0x5E</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Master]</group>
-        <key>headMix</key>
-        <status>0xB0</status>
-        <midino>0x32</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
+      <!-- T15_PRESS_SHIFT  = ? -->
       <control>
         <group>[Channel1]</group>
-        <key>pfl</key>
+        <key>Mixage.wheelTouch</key>
         <status>0x90</status>
-        <midino>0x0E</midino>
+        <midino>0x63</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
+      <!-- T15_TURN = Jog Wheel -->
       <control>
         <group>[Channel1]</group>
-        <key>volume</key>
+        <key>Mixage.wheelTurn</key>
         <status>0xB0</status>
-        <midino>0x38</midino>
+        <midino>0x24</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>rate</key>
-        <status>0xE1</status>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>volume</key>
-        <status>0xB0</status>
-        <midino>0x3E</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
+      <!-- T15_TURN_SHIFT = ? -->
       <control>
         <group>[Channel1]</group>
-        <key>rate</key>
-        <status>0xE0</status>
+        <key>Mixage.wheelTurn</key>
+        <status>0xB0</status>
+        <midino>0x63</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
+      <!-- T16 = Sync Button-->
       <control>
-        <group>[Channel2]</group>
-        <key>play</key>
+        <group>[Channel1]</group>
+        <key>sync_enabled</key>
         <status>0x90</status>
-        <midino>0x1A</midino>
+        <midino>0x09</midino>
         <options>
           <normal />
         </options>
       </control>
-      <control>
-        <group>[PreviewDeck1]</group>
-        <key>play</key>
-        <status>0x90</status>
-        <midino>0x4D</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[PreviewDeck1]</group>
-        <key>stop</key>
-        <status>0x90</status>
-        <midino>0x5B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
+      <!-- T16_SHIFT = Cue 1 -->
       <control>
         <group>[Channel1]</group>
         <key>hotcue_1_activate</key>
@@ -703,6 +391,17 @@
           <normal />
         </options>
       </control>
+      <!-- T17 = Cup Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>cue_play</key>
+        <status>0x90</status>
+        <midino>0x0A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T17_SHIFT = Cue 2 -->
       <control>
         <group>[Channel1]</group>
         <key>hotcue_2_activate</key>
@@ -712,6 +411,17 @@
           <normal />
         </options>
       </control>
+      <!-- T18 = Cue Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>cue_default</key>
+        <status>0x90</status>
+        <midino>0x0B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T18_SHIFT = Cue 3 -->
       <control>
         <group>[Channel1]</group>
         <key>hotcue_3_activate</key>
@@ -721,6 +431,17 @@
           <normal />
         </options>
       </control>
+      <!-- T19 = Play/Pause -->
+      <control>
+        <group>[Channel1]</group>
+        <key>play</key>
+        <status>0x90</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T19_SHIFT = Cue 4 -->
       <control>
         <group>[Channel1]</group>
         <key>hotcue_4_activate</key>
@@ -730,6 +451,496 @@
           <normal />
         </options>
       </control>
+      <!-- T21 = Track Load Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>Mixage.handleTrackLoading</key>
+        <status>0x90</status>
+        <midino>0x0D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T21_SHIFT = Open folder -->
+      <control>
+        <group>[Library]</group>
+        <key>MoveLeft</key>
+        <status>0x90</status>
+        <midino>0x4C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T22 = High EQ Dial -->
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>parameter3</key>
+        <status>0xB0</status>
+        <midino>0x35</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T22_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x74</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T23 = Mids EQ Dial -->
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>parameter2</key>
+        <status>0xB0</status>
+        <midino>0x36</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T23_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x75</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T24 = Low EQ Dial -->
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>parameter1</key>
+        <status>0xB0</status>
+        <midino>0x37</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T24_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x76</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T25 = PFL Button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>pfl</key>
+        <status>0x90</status>
+        <midino>0x0E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T25_SHIFT = Track Pre-Listen Play -->
+      <control>
+        <group>[PreviewDeck1]</group>
+        <key>LoadSelectedTrackAndPlay</key>
+        <status>0x90</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T26  = Line Fader -->
+      <control>
+        <group>[Channel1]</group>
+        <key>volume</key>
+        <status>0xB0</status>
+        <midino>0x38</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T26_SHIFT = ? -->
+      <control>
+        <group>[Channel1]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x77</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T1 = Pitch Bend Minus Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>rate_temp_down</key>
+        <status>0x90</status>
+        <midino>0x0F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T1_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>beats_translate_earlier</key>
+        <status>0x90</status>
+        <midino>0x4E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T2 = Pitch Bend Plus Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>rate_temp_up</key>
+        <status>0x90</status>
+        <midino>0x10</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T2_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>beats_translate_later</key>
+        <status>0x90</status>
+        <midino>0x4F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T3 = Shift Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleShift</key>
+        <status>0x90</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T4 = Autoloop -->
+      <control>
+        <group>[Channel2]</group>
+        <key>beatloop_activate</key>
+        <status>0x90</status>
+        <midino>0x13</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T4_SHIFT = Loop in -->
+      <control>
+        <group>[Channel2]</group>
+        <key>loop_in</key>
+        <status>0x90</status>
+        <midino>0x52</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T5_TURN = Loop Length -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleLoopLength</key>
+        <status>0xB0</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T5_TURN_SHIFT = Beat Move -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleBeatMove</key>
+        <status>0xB0</status>
+        <midino>0x61</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T5_PRESS = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleBeatMovePressed</key>
+        <status>0x90</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T5_PRESS_SHIFT = Activate/Deactivate Loop -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x61</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T6 = Gain Dial -->
+      <control>
+        <group>[Channel2]</group>
+        <key>pregain</key>
+        <status>0xB0</status>
+        <midino>0x39</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T6_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x78</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T7 = Pitch Fader -->
+      <control>
+        <group>[Channel2]</group>
+        <key>rate</key>
+        <status>0xE1</status>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T8 = Reloop -->
+      <control>
+        <group>[Channel2]</group>
+        <key>reloop_toggle</key>
+        <status>0x90</status>
+        <midino>0x14</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T8_SHIFT = Loop Out -->
+      <control>
+        <group>[Channel2]</group>
+        <key>loop_out</key>
+        <status>0x90</status>
+        <midino>0x53</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T9 = FX Select Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.nextEffect</key>
+        <status>0x90</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T9_SHIFT = Master Deck Assignment -->
+      <control>
+        <group>[Channel2]</group>
+        <key>sync_master</key>
+        <status>0x90</status>
+        <midino>0x54</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T10_TURN = FX Dry/Wet Dial -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleEffectDryWet</key>
+        <status>0xB0</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T10_TURN_SHIFT = Pan Balance Dial -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handlePan</key>
+        <status>0xB0</status>
+        <midino>0x62</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T10_PRESS = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleDryWetPressed</key>
+        <status>0x90</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T10_PRESS_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x62</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T11_TURN = FX Amount Dail -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleFxAmount</key>
+        <status>0xB0</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T11_TURN_SHIFT = Filter Dial -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleFilter</key>
+        <status>0xB0</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T11_CENTER = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x3A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T11_CENTER_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0x90</status>
+        <midino>0x79</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T12 = FX On Button -->
+      <control>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>group_[Channel2]_enable</key>
+        <status>0x90</status>
+        <midino>0x16</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T12_SHIFT = Keylock Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>keylock</key>
+        <status>0x90</status>
+        <midino>0x55</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T13 = Search Mode Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.scrollToggle</key>
+        <status>0x90</status>
+        <midino>0x11</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T13_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.scrollToggle</key>
+        <status>0x90</status>
+        <midino>0x31</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T14 = Scratch Mode Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.scratchToggle</key>
+        <status>0x90</status>
+        <midino>0x12</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T14_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.scratchToggle</key>
+        <status>0x90</status>
+        <midino>0x51</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T15_PRESS = Jog Wheel -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.wheelTouch</key>
+        <status>0x90</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T15_PRESS_SHIFT  = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.wheelTouch</key>
+        <status>0x90</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T15_TURN = Jog Wheel -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.wheelTurn</key>
+        <status>0xB0</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T15_TURN_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.wheelTurn</key>
+        <status>0xB0</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T16 = Sync Button-->
+      <control>
+        <group>[Channel2]</group>
+        <key>sync_enabled</key>
+        <status>0x90</status>
+        <midino>0x17</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T16_SHIFT = Cue 1 -->
       <control>
         <group>[Channel2]</group>
         <key>hotcue_1_activate</key>
@@ -739,6 +950,17 @@
           <normal />
         </options>
       </control>
+      <!-- T17 = Cup Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>cue_play</key>
+        <status>0x90</status>
+        <midino>0x18</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T17_SHIFT = Cue 2 -->
       <control>
         <group>[Channel2]</group>
         <key>hotcue_2_activate</key>
@@ -748,6 +970,17 @@
           <normal />
         </options>
       </control>
+      <!-- T18 = Cue Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>cue_default</key>
+        <status>0x90</status>
+        <midino>0x19</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T18_SHIFT = Cue 3 -->
       <control>
         <group>[Channel2]</group>
         <key>hotcue_3_activate</key>
@@ -757,6 +990,17 @@
           <normal />
         </options>
       </control>
+      <!-- T19 = Play/Pause -->
+      <control>
+        <group>[Channel2]</group>
+        <key>play</key>
+        <status>0x90</status>
+        <midino>0x1A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T19_SHIFT = Cue 4 -->
       <control>
         <group>[Channel2]</group>
         <key>hotcue_4_activate</key>
@@ -766,7 +1010,272 @@
           <normal />
         </options>
       </control>
+      <!-- T21 = Track Load Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>Mixage.handleTrackLoading</key>
+        <status>0x90</status>
+        <midino>0x1B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T21_SHIFT = Close folder -->
+      <control>
+        <group>[Library]</group>
+        <key>MoveRight</key>
+        <status>0x90</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T22 = High EQ Dial -->
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>parameter3</key>
+        <status>0xB0</status>
+        <midino>0x3B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T22_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x7A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T23 = Mids EQ Dial -->
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>parameter2</key>
+        <status>0xB0</status>
+        <midino>0x3C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T23_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x7B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T24 = Low EQ Dial -->
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>parameter1</key>
+        <status>0xB0</status>
+        <midino>0x3D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T24_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x7C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T25 = PFL Button -->
+      <control>
+        <group>[Channel2]</group>
+        <key>pfl</key>
+        <status>0x90</status>
+        <midino>0x1C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T25_SHIFT = Track Pre-Listen Stop -->
+      <control>
+        <group>[PreviewDeck1]</group>
+        <key>stop</key>
+        <status>0x90</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T26  = Line Fader -->
+      <control>
+        <group>[Channel2]</group>
+        <key>volume</key>
+        <status>0xB0</status>
+        <midino>0x3E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T26_SHIFT = ? -->
+      <control>
+        <group>[Channel2]</group>
+        <key></key>
+        <status>0xB0</status>
+        <midino>0x7D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T20_PRESS = Maximize Song Browser -->
+      <control>
+        <group>[Master]</group>
+        <key>Mixage.handleTraxPress</key>
+        <status>0x90</status>
+        <midino>0x1F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T20_PRESS_SHIFT = ? -->
+      <control>
+        <group>[Master]</group>
+        <key>Mixage.handleTraxPress</key>
+        <status>0x90</status>
+        <midino>0x5E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T20_TURN = Trax Encoder -->
+      <control>
+        <group>[Library]</group>
+        <key>Mixage.handleTraxTurn</key>
+        <status>0xB0</status>
+        <midino>0x1F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T20_TURN_SHIFT = Folder Navigation -->
+      <control>
+        <group>[Library]</group>
+        <key>Mixage.handleTraxTurn</key>
+        <status>0xB0</status>
+        <midino>0x5E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- T29 = Cue Mix Fader -->
+      <control>
+        <group>[Master]</group>
+        <key>headMix</key>
+        <status>0xB0</status>
+        <midino>0x32</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <!-- T33 = Crossfader -->
+      <control>
+        <group>[Master]</group>
+        <key>crossfader</key>
+        <status>0xB0</status>
+        <midino>0x31</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
     </controls>
-    <outputs />
+    <outputs>
+      <output>
+        <group>[EffectRack1_EffectUnit1]</group>
+        <key>group_[Channel1]_enable</key>
+        <status>0x90</status>
+        <midino>0x08</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>group_[Channel1]_enable</key>
+        <status>0x90</status>
+        <midino>0x08</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[EffectRack1_EffectUnit3]</group>
+        <key>group_[Channel1]_enable</key>
+        <status>0x90</status>
+        <midino>0x08</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[EffectRack1_EffectUnit4]</group>
+        <key>group_[Channel1]_enable</key>
+        <status>0x90</status>
+        <midino>0x08</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[EffectRack1_EffectUnit1]</group>
+        <key>group_[Channel2]_enable</key>
+        <status>0x90</status>
+        <midino>0x16</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>group_[Channel2]_enable</key>
+        <status>0x90</status>
+        <midino>0x16</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[EffectRack1_EffectUnit3]</group>
+        <key>group_[Channel2]_enable</key>
+        <status>0x90</status>
+        <midino>0x16</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[EffectRack1_EffectUnit4]</group>
+        <key>group_[Channel2]_enable</key>
+        <status>0x90</status>
+        <midino>0x16</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[Channel1]</group>
+        <key>beats_translate_earlier</key>
+        <status>0x90</status>
+        <midino>0x01</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[Channel1]</group>
+        <key>beats_translate_later</key>
+        <status>0x90</status>
+        <midino>0x02</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[Channel1]</group>
+        <key>rate_temp_down</key>
+        <status>0x90</status>
+        <midino>0x01</midino>
+        <minimum>0.5</minimum>
+      </output>
+      <output>
+        <group>[Channel1]</group>
+        <key>rate_temp_up</key>
+        <status>0x90</status>
+        <midino>0x02</midino>
+        <minimum>0.5</minimum>
+      </output>
+    </outputs>
   </controller>
 </MixxxControllerPreset>

--- a/res/controllers/Reloop-Mixage.scripts.js
+++ b/res/controllers/Reloop-Mixage.scripts.js
@@ -16,7 +16,6 @@ Mixage.vuMeterConnection = [];
 Mixage.loopConnection = [];
 Mixage.fxOnConnection = [];
 Mixage.fxSelectConnection = [];
-Mixage.fxPresetConnection = [];
 
 // timers
 Mixage.traxxPressTimer = 0;
@@ -84,8 +83,6 @@ Mixage.adjustLoopOut = {
 Mixage.effectSlotState = {
     "[EffectRack1_EffectUnit1]": new Array(Mixage.numEffectSlots).fill(1),
     "[EffectRack1_EffectUnit2]": new Array(Mixage.numEffectSlots).fill(1),
-    "[EffectRack1_EffectUnit3]": new Array(Mixage.numEffectSlots).fill(1),
-    "[EffectRack1_EffectUnit4]": new Array(Mixage.numEffectSlots).fill(1),
 };
 
 Mixage.blinkTimer = {
@@ -189,7 +186,6 @@ Mixage.init = function(_id, _debugging) {
         Mixage.vuMeterConnection.push(engine.makeConnection(channel, "vu_meter", function(val) { midi.sendShortMsg(0x90, Mixage.ledMap[channel].vu_meter, val * 7); }));
         Mixage.loopConnection.push(engine.makeConnection(channel, "track_loaded", function() { Mixage.toggleReloopLED(channel); }));
         Mixage.fxSelectConnection.push(engine.makeConnection("[EffectRack1_EffectUnit"+deck+"]", "focused_effect", function(value) { Mixage.handleFxSelect(value, channel); }));
-        // Mixage.fxPresetConnection.push(engine.makeConnection("[EffectRack1_EffectUnit"+deck+"]", "loaded_chain_preset", function(_v, g) { Mixage.getLoadedPresetEffects(g); }));
 
         // get current status and set LEDs accordingly
         Mixage.toggleFxLED(channel);
@@ -204,7 +200,6 @@ Mixage.shutdown = function() {
     Mixage.loopConnection.forEach(function(connection) { connection.disconnect(); });
     Mixage.fxSelectConnection.forEach(function(connection) { connection.disconnect(); });
     Mixage.fxOnConnection.forEach(function(connection) { connection.disconnect(); });
-    Mixage.fxPresetConnection.forEach(function(connection) { connection.disconnect(); });
 
     // Disconnect all controls from functions
     Mixage.channels.forEach(function(channel) { Mixage.connectControlsToFunctions(channel, true); });
@@ -425,20 +420,8 @@ Mixage.toggleEffect = function(group) {
             }
         }
     } else {
-        script.toggleControl("[" + effectUnitGroup + "_Effect" + focusedEffect + "]", "enabled");
+        script.toggleControl("[" + effectUnit + "_Effect" + focusedEffect + "]", "enabled");
     }
-};
-
-Mixage.getLoadedPresetEffects = function(effectUnit) {
-    var loadedFxSlots = [];
-
-    for (var effectSlot = 1; effectSlot <= Mixage.numEffectSlots; effectSlot++) {
-        var effectSlotString =  effectUnit.slice(0, -1) + "_Effect" + effectSlot + "]";
-        loadedFxSlots.push(engine.getValue(effectSlotString, "loaded"));
-        engine.setValue(effectSlotString, "enabled", 0);
-    }
-
-    Mixage.effectSlotState[effectUnit] = loadedFxSlots;
 };
 
 // ----- functions mapped to buttons -----

--- a/res/controllers/Reloop-Mixage.scripts.js
+++ b/res/controllers/Reloop-Mixage.scripts.js
@@ -166,7 +166,7 @@ Mixage.connectionMap = {
         "play_indicator": [function(v, g, c) { Mixage.handlePlay(v, g, c); }, null],
         "pfl": [function(v, g, c) { Mixage.toggleLED(v, g, c); }, null],
         "loop_enabled": [function(v, g, c) { Mixage.toggleLED(v, g, c); }, null],
-        "sync_enabled": [function(v, g, c) { Mixage.toggleLoopLED(v, g, c); }, null],
+        "sync_enabled": [function(v, g, c) { Mixage.toggleLED(v, g, c); }, null],
     },
 };
 

--- a/res/controllers/Reloop-Mixage.scripts.js
+++ b/res/controllers/Reloop-Mixage.scripts.js
@@ -21,6 +21,7 @@ Mixage.fxSelectConnection = [];
 Mixage.traxxPressTimer = 0;
 Mixage.loopLengthPressTimer = 0;
 Mixage.dryWetPressTimer = 0;
+Mixage.scratchTogglePressTimer = 0;
 
 // constants
 Mixage.numEffectUnits = 4;
@@ -633,15 +634,22 @@ Mixage.handleShift = function(_channel, _control, value, _status, group) {
 Mixage.scratchToggle = function(_channel, _control, value, _status, group) {
     if (value === DOWN) {
         Mixage.scratchPressed[group] = true;
-        Mixage.stopLoopAdjust(group);
-        Mixage.scratchToggleState[group] = !Mixage.scratchToggleState[group];
-        Mixage.toggleLED(Mixage.scratchToggleState[group], group, "scratch_active");
-        if (Mixage.scrollToggleState[group]) {
-            Mixage.scrollToggleState[group] = !Mixage.scrollToggleState[group];
-            Mixage.toggleLED(Mixage.scrollToggleState[group], group, "scroll_active");
-        }
+        Mixage.scratchTogglePressTimer = engine.beginTimer(400, function() {
+            Mixage.scratchTogglePressTimer = 0;
+        }, true);
     } else {
         Mixage.scratchPressed[group] = false;
+        if (Mixage.scratchTogglePressTimer !== 0) {
+            engine.stopTimer(Mixage.scratchTogglePressTimer);
+            Mixage.scratchTogglePressTimer = 0;
+            Mixage.stopLoopAdjust(group);
+            Mixage.scratchToggleState[group] = !Mixage.scratchToggleState[group];
+            Mixage.toggleLED(Mixage.scratchToggleState[group], group, "scratch_active");
+            if (Mixage.scrollToggleState[group]) {
+                Mixage.scrollToggleState[group] = !Mixage.scrollToggleState[group];
+                Mixage.toggleLED(Mixage.scrollToggleState[group], group, "scroll_active");
+            }
+        }
     }
 };
 

--- a/res/controllers/Reloop-Mixage.scripts.js
+++ b/res/controllers/Reloop-Mixage.scripts.js
@@ -1,38 +1,71 @@
 // Name: Reloop Mixage
 // Author: HorstBaerbel
-// Version: 1.0.4 needs Mixxx 2.1+
+// Version: 1.0.5 needs Mixxx 2.1+
 
 var Mixage = {};
 
 // ----- User-configurable settings -----
 Mixage.scratchByWheelTouch = false; // Set to true to scratch by touching the jog wheel instead of having to toggle the disc button. Default is false
 Mixage.scratchTicksPerRevolution = 620; // Number of jog wheel ticks that make a full revolution when scratching. Reduce to "scratch more" of the track, increase to "scratch less". Default is 620 (measured)
-Mixage.jogWheelScrollSpeed = 1.0; // Scroll speed when the jog wheel is used to scroll through the track. The higher, the faster. Default is 1.0
+Mixage.jogWheelScrollSpeed = 2.0; // Scroll speed when the jog wheel is used to scroll through the track. The higher, the faster. Default is 1.0
 Mixage.autoMaximizeLibrary = false; // Set to true to automatically max- and minimize the library when the browse button is used. Default is false
 Mixage.libraryHideTimeout = 4000; // Time in ms after which the library will automatically minimized. Default is 4000
 Mixage.libraryReducedHideTimeout = 500; // Time in ms after which the library will be minimized after loading a song into a deck. Default is 500
 
 // ----- Internal variables (don't touch) -----
+var ON = 0x7F, OFF = 0x00, DOWN = 0x7F;
+var QUICK_PRESS = 1, DOUBLE_PRESS = 2;
+
 Mixage.vuMeterConnection = [];
+Mixage.loopConnection = [];
+Mixage.beatConnection = [];
+Mixage.fxConnection = [];
 Mixage.libraryHideTimer = 0;
 Mixage.libraryRemainingTime = 0;
-// Note that the following lists have 3 entries, but we use only 2 decks / effect units. This saves us having to write "deckNr - 1" everywhere...
-Mixage.isBeatMovePressed = [false, false, false];
-Mixage.isDryWetPressed = [false, false, false];
-Mixage.scratchToggleLastState = [0, 0, 0]; // helper array to enable scratch toggling by disc button
-Mixage.isScratchActive = [false, false, false]; // true if scratching currently enabled for deck
-Mixage.scrollToggleLastState = [0, 0, 0]; // helper array to enable scroll toggling by loupe button
-Mixage.isScrollActive = [false, false, false]; // true if scrolling currently enabled for deck
-Mixage.effectRackSelected = [[true, false], [true, false], [true, false]]; // if effect rack 1/2 is selected for channel 1/2
-Mixage.effectRackEnabled = [false, false, false]; // if effect rack 1/2 is enabled for channel 1/2
+Mixage.doublePressTimer = 0;
+
+Mixage.scratchToggleState = {
+    "[Channel1]": false,
+    "[Channel2]": false,
+};
+
+Mixage.scrollToggleState = {
+    "[Channel1]": false,
+    "[Channel2]": false,
+};
+
+Mixage.scratching = {
+    "[Channel1]": false,
+    "[Channel2]": false,
+};
+
+Mixage.isBeatMovePressed = {
+    "[Channel1]": false,
+    "[Channel2]": false,
+};
+
+Mixage.syncLeader = {
+    "[Channel1]": engine.getValue("[Channel1]", "sync_master"),
+    "[Channel2]": engine.getValue("[Channel2]", "sync_master"),
+};
 
 Mixage.init = function(_id, _debugging) {
     // all button LEDs off
     for (var i = 0; i < 255; i++) {
         midi.sendShortMsg(0x90, i, 0);
     }
+
+    var numEffectSlots = engine.getValue("[EffectRack1_EffectUnit1]", "num_effects");
+    var numDecks = engine.getValue("[Master]", "num_decks");
+
+    print(numDecks);
+
     Mixage.connectControlsToFunctions("[Channel1]");
     Mixage.connectControlsToFunctions("[Channel2]");
+
+    engine.setValue("[EffectRack1_EffectUnit1]", "show_focus", 1);
+    engine.setValue("[EffectRack1_EffectUnit2]", "show_focus", 1);
+
     // make connection for updating the VU meters
     Mixage.vuMeterConnection[0] = engine.makeConnection("[Channel1]", "VuMeter", function(val) {
         midi.sendShortMsg(0x90, 29, val * 7);
@@ -40,26 +73,75 @@ Mixage.init = function(_id, _debugging) {
     Mixage.vuMeterConnection[1] = engine.makeConnection("[Channel2]", "VuMeter", function(val) {
         midi.sendShortMsg(0x90, 30, val * 7);
     });
-    // restore deck sync master LEDs (function currently not working as of 2.3.3)
-    //var isDeck1SyncLeader = engine.getValue("[Channel1]", "sync_master");
-    //Mixage.toggleLED(isDeck1SyncLeader ? 1 : 0, "[Channel1]", "sync_master");
-    //var isDeck2SyncLeader = engine.getValue("[Channel2]", "sync_master");
-    //Mixage.toggleLED(isDeck2SyncLeader ? 1 : 0, "[Channel2]", "sync_master");
-    // restore deck 1 effect states from user preferences
-    Mixage.effectRackSelected[1][0] = engine.getValue("[EffectRack1_EffectUnit1]", "group_[Channel1]_enable");
-    Mixage.effectRackSelected[1][1] = engine.getValue("[EffectRack1_EffectUnit2]", "group_[Channel1]_enable");
-    Mixage.effectRackEnabled[1] = Mixage.effectRackSelected[1][0] || Mixage.effectRackSelected[1][1];
-    Mixage.toggleLED(Mixage.effectRackEnabled[1] ? 1 : 0, "[Channel1]", "fx_on");
-    // restore deck 2 effect states from user preferences
-    Mixage.effectRackSelected[2][0] = engine.getValue("[EffectRack1_EffectUnit1]", "group_[Channel2]_enable");
-    Mixage.effectRackSelected[2][1] = engine.getValue("[EffectRack1_EffectUnit2]", "group_[Channel2]_enable");
-    Mixage.effectRackEnabled[2] = Mixage.effectRackSelected[2][0] || Mixage.effectRackSelected[2][1];
-    Mixage.toggleLED(Mixage.effectRackEnabled[2] ? 1 : 0, "[Channel2]", "fx_on");
+
+    // make connection for showing the beats on the loop button when a loop is active
+    Mixage.loopConnection[0] = engine.makeConnection("[Channel1]", "loop_enabled", function(value) {
+        if (value === 1) {
+            Mixage.beatConnection[0] = engine.makeConnection("[Channel1]", "beat_active", function(value) {
+                if (engine.getValue("[Channel1]", "beatloop_size") > 0.125) { Mixage.toggleLED(value, "[Channel1]", "loop"); } else {
+                    Mixage.toggleLED(ON, "[Channel1]", "loop");
+                }
+            });
+        } else {
+            Mixage.beatConnection[0].disconnect();
+            Mixage.toggleLED(OFF, "[Channel1]", "loop");
+        }
+    });
+    Mixage.loopConnection[1] = engine.makeConnection("[Channel2]", "loop_enabled", function(value) {
+        if (value === 1) {
+            Mixage.beatConnection[1] = engine.makeConnection("[Channel2]", "beat_active", function(value) {
+                if (engine.getValue("[Channel2]", "beatloop_size") > 0.125) { Mixage.toggleLED(value, "[Channel2]", "loop"); } else {
+                    Mixage.toggleLED(ON, "[Channel2]", "loop");
+                }
+            });
+        } else {
+            Mixage.beatConnection[1].disconnect();
+            Mixage.toggleLED(OFF, "[Channel2]", "loop");
+        }
+    });
+
+    Mixage.fxConnection[0] = engine.makeConnection("[EffectRack1_EffectUnit1]", "focused_effect", function(val) {
+        if (val === 0) {
+            Mixage.toggleLED(OFF, "[Channel1]", "fx_sel");
+            engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit1]", "super1");
+        } else {
+            Mixage.toggleLED(ON, "[Channel1]", "fx_sel");
+            engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit2_Effect" + val + "]", "meta");
+        }
+    });
+
+    Mixage.fxConnection[1] = engine.makeConnection("[EffectRack1_EffectUnit2]", "focused_effect", function(val) {
+        if (val === 0) {
+            Mixage.toggleLED(OFF, "[Channel2]", "fx_sel");
+            engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit1]", "super1");
+        } else {
+            Mixage.toggleLED(ON, "[Channel2]", "fx_sel");
+            engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit2_Effect" + val + "]", "meta");
+        }
+    });
+
+    engine.softTakeover("[EffectRack1_EffectUnit1]", "super1", true);
+    engine.softTakeover("[EffectRack1_EffectUnit2]", "super1", true);
+    engine.softTakeover("[QuickEffectRack1_[Channel1]]", "super1", true);
+    engine.softTakeover("[QuickEffectRack1_[Channel2]]", "super1", true);
+
+    for (var deck = 1; deck <= numDecks; deck++) {
+        for (var effect = 1; effect < numEffectSlots; effect++) {
+            var groupString = "[EffectRack1_EffectUnit"+ deck +"_Effect" + effect + "]";
+            engine.softTakeover(groupString, "meta", true);
+        }
+    }
 };
 
 Mixage.shutdown = function() {
     Mixage.vuMeterConnection[0].disconnect();
     Mixage.vuMeterConnection[1].disconnect();
+    Mixage.loopConnection[0].disconnect();
+    Mixage.loopConnection[1].disconnect();
+    Mixage.beatConnection[0].disconnect();
+    Mixage.beatConnection[1].disconnect();
+    Mixage.fxConnection[0].disconnect();
+    Mixage.fxConnection[1].disconnect();
     Mixage.connectControlsToFunctions("[Channel1]", true);
     Mixage.connectControlsToFunctions("[Channel2]", true);
     // all button LEDs off
@@ -76,12 +158,16 @@ Mixage.ledMap = {
         "play_indicator": 0x0C,
         "load_indicator": 0x0D,
         "pfl": 0x0E,
+        "loop": 0x05,
         "loop_enabled": 0x06,
         "sync_enabled": 0x09,
         "sync_master": 0x07,
         "fx_on": 0x08,
+        "fx_sel": 0x07,
         "scratch_active": 0x04,
         "scroll_active": 0x03,
+        "rate_temp_up": 0x02,
+        "rate_temp_down": 0x01,
     },
     "[Channel2]": {
         "cue_indicator": 0x18,
@@ -89,12 +175,16 @@ Mixage.ledMap = {
         "play_indicator": 0x1A,
         "load_indicator": 0x1B,
         "pfl": 0x1C,
+        "loop": 0x13,
         "loop_enabled": 0x14,
         "sync_enabled": 0x17,
         "sync_master": 0x15,
         "fx_on": 0x16,
+        "fx_sel": 0x15,
         "scratch_active": 0x12,
-        "scroll_active": 0x11
+        "scroll_active": 0x11,
+        "rate_temp_up": 0x10,
+        "rate_temp_down": 0x0f,
     }
 };
 
@@ -105,7 +195,7 @@ Mixage.connectionMap = {
     "play_indicator": [function(v, g, c) { Mixage.handlePlay(v, g, c); }, null],
     "pfl": [function(v, g, c) { Mixage.toggleLED(v, g, c); }, null],
     "loop_enabled": [function(v, g, c) { Mixage.toggleLED(v, g, c); }, null],
-    "sync_enabled": [function(v, g, c) { Mixage.toggleLED(v, g, c); }, null]
+    "sync_enabled": [function(v, g, c) { Mixage.toggleLED(v, g, c); }, null],
 };
 
 // Set or remove functions to call when the state of a mixxx control changes
@@ -122,7 +212,7 @@ Mixage.connectControlsToFunctions = function(group, remove) {
 
 // Toggle the LED on the MIDI controller by sending a MIDI message
 Mixage.toggleLED = function(value, group, control) {
-    midi.sendShortMsg(0x90, Mixage.ledMap[group][control], (value === 1) ? 0x7F : 0);
+    midi.sendShortMsg(0x90, Mixage.ledMap[group][control], (value === 1 || value) ? 0x7F : 0);
 };
 
 // Toggle the LED on play button and make sure the preview deck stops when starting to play in a deck
@@ -133,47 +223,6 @@ Mixage.handlePlay = function(value, group, control) {
     engine.setValue("[PreviewDeck1]", "stop", true);
     // toggle the LOAD button LED for the deck
     Mixage.toggleLED(value, group, "load_indicator");
-};
-
-// A button for the playlist was pressed
-Mixage.handleLibrary = function(channel, control, value, status, _group) {
-    // "push2browse" button was moved somehow
-    if (control === 0x1F || control === 0x5E) { // "push2browse" button was pushed or turned
-        if (Mixage.autoMaximizeLibrary) {
-            Mixage.setLibraryMaximized(true);
-        }
-        if (status === 0x90 && value === 0x7F) { // "push2browse" button was pushed
-            if (control === 0x5E) { // was shift pressed?
-                engine.setValue("[Library]", "GoToItem", true);
-            } else {
-                // stop the currently playing track. if it wasn't playing, start it
-                if (engine.getValue("[PreviewDeck1]", "play")) {
-                    engine.setValue("[PreviewDeck1]", "stop", true);
-                } else {
-                    engine.setValue("[PreviewDeck1]", "LoadSelectedTrackAndPlay", true);
-                }
-            }
-        } else if (status === 0xB0) { // "push2browse" button was turned
-            var newValue = value - 64;
-            if (control === 0x1F) { // was shift pressed?
-                engine.setValue("[Playlist]", "SelectTrackKnob", newValue);
-            } else {
-                engine.setValue("[Playlist]", "SelectPlaylist", newValue);
-            }
-        }
-    } else if (control === 0x0D || control === 0x4C) { // load into deck 1
-        if (value === 0x7F) {
-            engine.setValue("[PreviewDeck1]", "stop", true);
-            engine.setValue("[Channel1]", control === 0x4C ? "LoadSelectedTrackAndPlay" : "LoadSelectedTrack", true);
-            Mixage.libraryRemainingTime = Mixage.libraryReducedHideTimeout;
-        }
-    } else if (control === 0x1B || control === 0x5A) { // load into deck 2
-        if (value === 0x7F) {
-            engine.setValue("[PreviewDeck1]", "stop", true);
-            engine.setValue("[Channel2]", control === 0x5A ? "LoadSelectedTrackAndPlay" : "LoadSelectedTrack", true);
-            Mixage.libraryRemainingTime = Mixage.libraryReducedHideTimeout;
-        }
-    }
 };
 
 // Set the library visible and hide it when libraryHideTimeOut is reached
@@ -208,231 +257,247 @@ Mixage.libraryCheckTimeout = function() {
     }
 };
 
-// Switch the controller and Mixxx state for scratching
-Mixage.setScratching = function(deckNr, active) {
-    // check if setting changed
-    if (Mixage.isScratchActive[deckNr] !== active) {
-        Mixage.isScratchActive[deckNr] = active;
-        if (active) {
-            // turn off scrolling first
-            Mixage.setScrolling(deckNr, false);
-        } else {
-            engine.scratchDisable(deckNr);
+Mixage.handleTraxPress = function(channel, control, value, status, group) {
+    if (value === DOWN) {
+        if (Mixage.doublePressTimer === 0) { // first press
+            Mixage.doublePressTimer = engine.beginTimer(400, function() {
+                Mixage.TraxPressCallback(channel, control, value, status, group, QUICK_PRESS);
+            }, true);
+        } else { // 2nd press (before timer's out)
+            engine.stopTimer(Mixage.doublePressTimer);
+            Mixage.TraxPressCallback(channel, control, value, status, group, DOUBLE_PRESS);
         }
-        var controlString = "[Channel" + deckNr + "]";
-        Mixage.toggleLED(Mixage.isScratchActive[deckNr] ? 1 : 0, controlString, "scratch_active");
+    }
+};
+
+Mixage.handleTraxTurn = function(_channel, control, value, _status, _group) {
+    var newValue = value - 64;
+    if (Mixage.autoMaximizeLibrary) {
+        Mixage.setLibraryMaximized(true);
+    }
+    if (control === 0x5E) { // was shift pressed?
+        engine.setValue("[Playlist]", "SelectPlaylist", newValue);
+    } else {
+        engine.setValue("[Playlist]", "SelectTrackKnob", newValue);
+    }
+};
+
+Mixage.handleTrackLoading = function(_channel, control, value, _status, group) {
+    if (value === DOWN) {
+        engine.setValue("[PreviewDeck1]", "stop", true);
+        engine.setValue(group, control > 0x1B ? "LoadSelectedTrackAndPlay" : "LoadSelectedTrack", true);
+        Mixage.libraryRemainingTime = Mixage.libraryReducedHideTimeout;
+    }
+};
+
+Mixage.TraxPressCallback = function(_channel, _control, _value, _status, group, event) {
+    if (event === QUICK_PRESS) {
+        if (Mixage.autoMaximizeLibrary) {
+            Mixage.setLibraryMaximized(true);
+        }
+        if (engine.getValue("[PreviewDeck1]", "play")) {
+            engine.setValue("[PreviewDeck1]", "stop", true);
+        } else {
+            engine.setValue("[PreviewDeck1]", "LoadSelectedTrackAndPlay", true);
+        }
+    }
+    if (event === DOUBLE_PRESS) {
+        engine.setValue(group, "maximize_library", !engine.getValue(group, "maximize_library"));
+    }
+    Mixage.doublePressTimer = 0;
+};
+
+Mixage.nextEffect = function(_channel, _control, value, _status, group) {
+    var unitNr = script.deckFromGroup(group);
+    var controlString = "[EffectRack1_EffectUnit" + unitNr + "]";
+    //for some reason one more effect slot is returned than visible in the ui, thus the minus 1
+    var numEffectSlots = engine.getValue(controlString, "num_effectslots") - 1;
+    if (value === DOWN) {
+        if (engine.getValue(controlString, "focused_effect") === numEffectSlots) {
+            for (var i = 1; i === numEffectSlots; i++) {
+                var groupString = "[EffectRack1_EffectUnit" + unitNr + "_Effect" + i + "]";
+                engine.softTakeoverIgnoreNextValue(groupString, "meta");
+            }
+            engine.softTakeoverIgnoreNextValue(controlString, "super1");
+            engine.setValue(controlString, "focused_effect", 0);
+        } else {
+            var currentSelection = engine.getValue(controlString, "focused_effect");
+            engine.setValue(controlString, "focused_effect", currentSelection + 1);
+        }
+    }
+};
+
+Mixage.handleEffectDryWet = function(_channel, _control, value, _status, group) {
+    var unitNr = script.deckFromGroup(group);
+    var controlString = "[EffectRack1_EffectUnit" + unitNr + "]";
+    var diff = (value - 64); // 16.0;
+    if (Mixage.isBeatMovePressed[group]) {
+        Mixage.setFxChannels(diff);
+    } else if (engine.getValue(controlString, "focused_effect") === 0) {
+        var dryWetValue = engine.getValue(controlString, "mix");
+        engine.setValue(controlString, "mix", dryWetValue + (diff / 16.0));
+    } else {
+        var focussedEffect = engine.getValue(controlString, "focused_effect");
+        engine.setValue("[EffectRack1_EffectUnit" + unitNr + "_Effect" + focussedEffect + "]", "effect_selector", diff);
+    }
+};
+
+Mixage.handleDryWetPressed = function(_channel, _control, value, _status, group) {
+    var unitNr = script.deckFromGroup(group);
+    var controlString = "[EffectRack1_EffectUnit" + unitNr + "]";
+    var focussedEffect = engine.getValue(controlString, "focused_effect");
+    var numEffectSlots = engine.getValue(controlString, "num_effects");
+    if (value === DOWN && focussedEffect !== 0) {
+        var effectStatus = engine.getValue("[EffectRack1_EffectUnit" + unitNr + "_Effect" + focussedEffect + "]", "enabled");
+        engine.setValue("[EffectRack1_EffectUnit" + unitNr + "_Effect" + focussedEffect + "]", "enabled", !effectStatus);
+    }
+    if (value === DOWN && focussedEffect === 0) {
+        for (var i = 1; i < numEffectSlots; i++) {
+            engine.setValue("[EffectRack1_EffectUnit" + unitNr + "_Effect" + i + "]", "enabled", false);
+        }
+    }
+};
+
+Mixage.handleFxAmount = function(_channel, _control, value, _status, group) {
+    var unitNr = script.deckFromGroup(group);
+    var controlString = "[EffectRack1_EffectUnit" + unitNr + "]";
+    var focussedEffect = engine.getValue(controlString, "focused_effect");
+    if (focussedEffect === 0) {
+        engine.setValue(controlString, "super1", value / 127);
+    } else {
+        engine.setValue("[EffectRack1_EffectUnit" + unitNr + "_Effect" + focussedEffect + "]", "meta", value / 127);
+    }
+};
+
+Mixage.handleFxPress = function(_channel, _control, value, _status, group) {
+    if (value === DOWN) {
+        var numUnits = engine.getValue("[EffectRack1]", "num_effectunits");
+        var fxChannel = "group_" + group + "_enable";
+        var unitNr = script.deckFromGroup(group);
+        var enabledFxGroups = [];
+
+        for (var i = 1; i <= numUnits; i++) {
+            enabledFxGroups.push(engine.getValue("[EffectRack1_EffectUnit" + i + "]", fxChannel));
+        }
+
+        if (enabledFxGroups.indexOf(1) !== -1) {
+            for (var effectUnit = 1; effectUnit <= numUnits; effectUnit++) {
+                engine.setValue("[EffectRack1_EffectUnit" + effectUnit + "]", fxChannel, false);
+            }
+        } else {
+            engine.setValue("[EffectRack1_EffectUnit" + unitNr + "]", fxChannel, true);
+        }
+    }
+};
+
+// This function is necessary to allow for soft takeover of the filter amount button
+// see https://github.com/mixxxdj/mixxx/wiki/Midi-Scripting#soft-takeover
+Mixage.handleFilter = function(_channel, _control, value, _status, group) {
+    engine.setValue("[QuickEffectRack1_"+ group +"]", "super1", value / 127);
+};
+
+//Handles setting soft takeovers when pressing shift
+Mixage.handleShift = function(_channel, _control, value, _status, group) {
+    if (value === DOWN) {
+        var unitNr = script.deckFromGroup(group);
+        engine.softTakeoverIgnoreNextValue("[QuickEffectRack1_"+group+"]", "super1");
+        engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit"+unitNr+"]", "super1");
     }
 };
 
 // The "disc" button that enables/disables scratching
-Mixage.scratchToggle = function(channel, control, value, _status, _group) {
-    // calculate deck number from MIDI control. 0x04 controls deck 1, 0x12 deck 2
-    var deckNr = control === 0x04 ? 1 : 2;
+Mixage.scratchToggle = function(_channel, _control, value, _status, group) {
     // check for pressed->release or released->press
-    if (Mixage.scratchToggleLastState[deckNr] !== value) {
-        Mixage.scratchToggleLastState[deckNr] = value;
-        if (value === 0) {
-            return;
+    if (value === DOWN) {
+        Mixage.scratchToggleState[group] = !Mixage.scratchToggleState[group];
+        Mixage.toggleLED(Mixage.scratchToggleState[group], group, "scratch_active");
+        if (Mixage.scrollToggleState[group]) {
+            Mixage.scrollToggleState[group] = !Mixage.scrollToggleState[group];
+            Mixage.toggleLED(Mixage.scrollToggleState[group], group, "scroll_active");
         }
-        Mixage.setScratching(deckNr, !Mixage.isScratchActive[deckNr]);
-    }
-};
-
-// Switch the controller and Mixxx state for scrolling
-Mixage.setScrolling = function(deckNr, active) {
-    // check if setting changed
-    if (Mixage.isScrollActive[deckNr] !== active) {
-        Mixage.isScrollActive[deckNr] = active;
-        if (active) {
-            // turn off scratching first
-            Mixage.setScratching(deckNr, false);
-        } else {
-            engine.scratchDisable(deckNr);
-        }
-        var controlString = "[Channel" + deckNr + "]";
-        Mixage.toggleLED(Mixage.isScrollActive[deckNr] ? 1 : 0, controlString, "scroll_active");
     }
 };
 
 // The "loupe" button that enables/disables track scrolling
-Mixage.scrollToggle = function(channel, control, value, _status, _group) {
-    // calculate deck number from MIDI control. 0x03 controls deck 1, 0x12 deck 2
-    var deckNr = control === 0x03 ? 1 : 2;
+Mixage.scrollToggle = function(_channel, _control, value, _status, group) {
     // check for pressed->release or released->press
-    if (Mixage.scrollToggleLastState[deckNr] !== value) {
-        Mixage.scrollToggleLastState[deckNr] = value;
-        if (value === 0) {
-            return;
+    if (value === DOWN) {
+        Mixage.scrollToggleState[group] = !Mixage.scrollToggleState[group];
+        Mixage.toggleLED(Mixage.scrollToggleState[group], group, "scroll_active");
+        if (Mixage.scratchToggleState[group]) {
+            Mixage.scratchToggleState[group] = !Mixage.scratchToggleState[group];
+            Mixage.toggleLED(Mixage.scratchToggleState[group], group, "scratch_active");
         }
-        Mixage.setScrolling(deckNr, !Mixage.isScrollActive[deckNr]);
     }
 };
 
 // The touch function on the wheels that enables/disables scratching
-Mixage.wheelTouch = function(channel, control, value, _status, _group) {
-    // calculate deck number from MIDI control. 0x24 controls deck 1, 0x25 deck 2
-    var deckNr = control === 0x24 ? 1 : 2;
+Mixage.wheelTouch = function(_channel, _control, value, _status, group) {
+    var unitNr = script.deckFromGroup(group);
     // check if scratching should be enabled
-    if (Mixage.scratchByWheelTouch || Mixage.isScratchActive[deckNr]) {
-        if (value === 0x7F) {
+    if (Mixage.scratchByWheelTouch || Mixage.scratchToggleState[group]) {
+        if (value === DOWN) {
             // turn on scratching on this deck
             var alpha = 1.0 / 8.0;
             var beta = alpha / 32.0;
-            engine.scratchEnable(deckNr, Mixage.scratchTicksPerRevolution, 33.0 + 1.0 / 3.0, alpha, beta);
+            engine.scratchEnable(unitNr, Mixage.scratchTicksPerRevolution, 33.33, alpha, beta);
+            Mixage.scratching[group] = true;
         } else {
-            engine.scratchDisable(deckNr);
+            engine.scratchDisable(unitNr);
+            Mixage.scratching[group] = false;
         }
     }
 };
 
 // The wheel that controls the scratching / jogging
-Mixage.wheelTurn = function(channel, control, value, _status, _group) {
+Mixage.wheelTurn = function(_channel, _control, value, _status, group) {
     // calculate deck number from MIDI control. 0x24 controls deck 1, 0x25 deck 2
-    var deckNr = control === 0x24 ? 1 : 2;
+    var deckNr = script.deckFromGroup(group);
     // only enable wheel if functionality has been enabled
-    if (Mixage.scratchByWheelTouch || Mixage.isScratchActive[deckNr] || Mixage.isScrollActive[deckNr]) {
+    if (Mixage.scratchByWheelTouch || Mixage.scratchToggleState[group] || Mixage.scrollToggleState[group]) {
         // control centers on 0x40 (64), calculate difference to that value
         var newValue = value - 64;
-        if (Mixage.isScrollActive[deckNr]) { // scroll deck
-            var controlString = "[Channel" + deckNr + "]";
-            var keyString = "playposition";// + newValue > 0 ? "up_small" : "down_small";
-            var currentPosition = engine.getValue(controlString, keyString);
+        if (Mixage.scrollToggleState[group]) { // scroll deck
+            var currentPosition = engine.getValue(group, "playposition");
             var speedFactor = 0.00005;
-            engine.setValue(controlString, keyString, currentPosition + speedFactor * newValue * Mixage.jogWheelScrollSpeed);
-        } else if (engine.isScratching(deckNr)) {
+            engine.setValue(group, "playposition", currentPosition + speedFactor * newValue * Mixage.jogWheelScrollSpeed);
+        } else if (Mixage.scratching[group]) {
             engine.scratchTick(deckNr, newValue); // scratch deck
         } else {
-            engine.setValue("[Channel" + deckNr + "]", "jog", newValue); // pitch bend deck
+            engine.setValue(group, "jog", newValue); // pitch bend deck
         }
     }
 };
 
-// The MASTER button that toggles a deck as sync leader / master
-Mixage.handleDeckSyncMode = function(_channel, _control, _value, _status, _group) {
-    // Function currently not working as of 2.3.3: https://manual.mixxx.org/2.4/gl/chapters/appendix/mixxx_controls.html#control-[ChannelN]-sync_master
-    // Disable until this is working
-    /*// calculate effect unit number from MIDI control. 0x46 controls unit 1, 0x54 unit 2
-    var deckNr = control === 0x46 ? 1 : 2;
-    // react only on first message / keydown
-    if (value === 0x7F) {
-        // check and toggle enablement
-        var controlString = "[Channel" + deckNr + "]";
-        var keyString = "sync_master";
-        var isSyncLeader = !engine.getValue(controlString, keyString);
-        // if we want to make this deck sync leader, turn off sync leader on the other deck
-        if (isSyncLeader) {
-        	var otherDeckNr = deckNr === 1 ? 2 : 1;
-        	engine.setValue("[Channel" + otherDeckNr + "]", keyString, false);
-        }
-        engine.setValue(controlString, keyString, isSyncLeader);
-        Mixage.toggleLED(isSyncLeader ? 1 : 0, controlString, keyString);
-    }*/
+Mixage.handleBeatMove = function(_channel, _control, value, _status, group) {
+    // control centers on 0x40 (64), calculate difference to that
+    var diff = (value - 64);
+    var position = diff > 0 ? "beatjump_forward" : "beatjump_backward";
+    engine.setValue(group, position, true);
 };
 
-// The FX ON button that toggles routing channel 1/2 through effects
-Mixage.handleEffectChannelOn = function(channel, control, value, _status, _group) {
-    // calculate effect unit number from MIDI control. 0x08 controls unit 1, 0x16 unit 2
-    var unitNr = control === 0x08 ? 1 : 2;
-    // react only on first message / keydown
-    if (value === 0x7F) {
-        // check and toggle enablement
-        Mixage.effectRackEnabled[unitNr] = !Mixage.effectRackEnabled[unitNr];
-        var isEnabled = Mixage.effectRackEnabled[unitNr];
-        // update controls
-        var keyString = "group_[Channel" + unitNr + "]_enable";
-        engine.setValue("[EffectRack1_EffectUnit1]", keyString, isEnabled && Mixage.effectRackSelected[unitNr][0]);
-        engine.setValue("[EffectRack1_EffectUnit2]", keyString, isEnabled && Mixage.effectRackSelected[unitNr][1]);
-        Mixage.toggleLED(isEnabled ? 1 : 0, "[Channel" + unitNr + "]", "fx_on");
+Mixage.handleBeatMovePressed = function(_channel, _control, value, _status, group) {
+    Mixage.isBeatMovePressed[group] = value === DOWN ? true : false;
+};
+
+Mixage.handleLoopLength = function(_channel, _control, value, _status, group) {
+    // control centers on 0x40 (64), calculate difference to that
+    var diff = (value - 64);
+    if (Mixage.isBeatMovePressed[group]) {
+        var beatjumpSize = engine.getParameter(group, "beatjump_size");
+        var newBeatJumpSize = diff > 0 ? 2 * beatjumpSize : beatjumpSize / 2;
+        engine.setParameter(group, "beatjump_size", newBeatJumpSize);
+    } else {
+        var loopScale = diff > 0 ? "loop_double" : "loop_halve";
+        engine.setValue(group, loopScale, true);
+        print(engine.getValue(group, "beatloop_size"));
     }
-};
-
-// The FX SEL button that selects which effects are enabled for channel 1/2
-Mixage.handleEffectChannelSelect = function(channel, control, value, _status, _group) {
-    // calculate effect unit number from MIDI control. 0x07 controls unit 1, 0x15 unit 2
-    var unitNr = control === 0x07 ? 1 : 2;
-    // react only on first message / keydown
-    if (value === 0x7F) {
-        // check and toggle select state
-        var selected1 = Mixage.effectRackSelected[unitNr][0];
-        var selected2 = Mixage.effectRackSelected[unitNr][1];
-        if (selected1 && selected2) {
-            selected1 = true;
-            selected2 = false;
-        } else if (selected1) {
-            selected1 = false;
-            selected2 = true;
-        } else {
-            selected1 = true;
-            selected2 = true;
-        }
-        Mixage.effectRackSelected[unitNr][0] = selected1;
-        Mixage.effectRackSelected[unitNr][1] = selected2;
-        // update controls
-        var isEnabled = Mixage.effectRackEnabled[unitNr];
-        var keyString = "group_[Channel" + unitNr + "]_enable";
-        engine.setValue("[EffectRack1_EffectUnit1]", keyString, isEnabled && Mixage.effectRackSelected[unitNr][0]);
-        engine.setValue("[EffectRack1_EffectUnit2]", keyString, isEnabled && Mixage.effectRackSelected[unitNr][1]);
-    }
-};
-
-// The -DRY/WET+ rotary control is used as an extra "shift" key when pushed down
-Mixage.handleDryWetPressed = function(channel, control, value, _status, _group) {
-    // calculate effect unit number from MIDI control. 0x21 controls unit 1, 0x25 unit 2
-    var unitNr = control === 0x21 ? 1 : 2;
-    Mixage.isDryWetPressed[unitNr] = value === 0x7f;
-};
-
-// The -DRY/WET+ rotary control used for the effect dry/wet mix
-Mixage.handleEffectDryWet = function(channel, control, value, _status, _group) {
-    // calculate effect unit number from MIDI control. 0x21 controls unit 1, 0x25 unit 2
-    var unitNr = control === 0x21 ? 1 : 2;
-    // control centers on 0x40 (64), calculate difference to that value and scale down
-    var diff = (value - 64) / 16.0;
-    var controlString = "[EffectRack1_EffectUnit" + unitNr + "]";
-    var keyString = Mixage.isDryWetPressed[unitNr] ? "super1" : "mix";
-    var dryWetValue = engine.getValue(controlString, keyString);
-    engine.setValue(controlString, keyString, dryWetValue + diff);
 };
 
 // The PAN rotary control used here for panning the master
-Mixage.handlePan = function(channel, control, value, _status, _group) {
+Mixage.handlePan = function(_channel, _control, value, _status, _group) {
     // control centers on 0x40 (64), calculate difference to that value and scale down
     var diff = (value - 64) / 16.0;
-    var controlString = "[Master]";
-    var keyString = "balance";
-    var mixValue = engine.getValue(controlString, keyString);
-    engine.setValue(controlString, keyString, mixValue + diff);
-};
-
-// The BEAT MOVE rotary control is used as an extra "shift" key when pushed down
-Mixage.handleBeatMovePressed = function(channel, control, value, _status, _group) {
-    // calculate effect unit number from MIDI control. 0x20 controls unit 1, 0x22 unit 2
-    var unitNr = control === 0x20 ? 1 : 2;
-    Mixage.isBeatMovePressed[unitNr] = value === 0x7f;
-};
-
-Mixage.handleBeatMoveLength = function(channel, control, value, _status, _group) {
-    // calculate effect unit number from MIDI control. 0x20 controls unit 1, 0x22 unit 2
-    var unitNr = control === 0x20 ? 1 : 2;
-    var direction = unitNr === 1 ? 1 : -1;
-    // control centers on 0x40 (64), calculate difference to that
-    var diff = (value - 64);
-    if (Mixage.isBeatMovePressed[unitNr]) {
-        var loopLength = engine.getParameter("[Channel" + unitNr + "]", "beatjump_size");
-        loopLength = direction * diff > 0 ? 2 * loopLength : loopLength / 2;
-        engine.setParameter("[Channel" + unitNr + "]", "beatjump_size", loopLength);
-    } else {
-        var loopScale = direction * diff > 0 ? "loop_double" : "loop_halve";
-        engine.setValue("[Channel" + unitNr + "]", loopScale, true);
-    }
-};
-
-Mixage.handleBeatMove = function(channel, control, value, _status, _group) {
-    // calculate effect unit number from MIDI control. 0x5F controls unit 1, 0x61 unit 2
-    var unitNr = control === 0x5f ? 1 : 2;
-    var direction = unitNr === 1 ? 1 : -1;
-    // control centers on 0x40 (64), calculate difference to that
-    var diff = (value - 64);
-    var position = direction * diff > 0 ? "beatjump_forward" : "beatjump_backward";
-    engine.setValue("[Channel" + unitNr + "]", position, true);
+    var mixValue = engine.getValue("[Master]", "balance");
+    engine.setValue("[Master]", "balance", mixValue + diff);
 };


### PR DESCRIPTION
### General

- Replaced lists with dictionaries to store channel variables
- Changed the default jog scroll speed to 2, so it also works properly when a track is playing
- Added global `ON`, `OFF`, `DOWN`, variables to improve code readability
- Rewritten `init` so al bindings and engine connections are set in a `foreach`loop in preparation for the addition of deck 3 & 4
- Rewritten `shutdown` so disconnecting all connections is done in `foreach` loops
- Added `Channel2` to the connectionMap and changed the `connectControlsToFunctions` function to make sure the connections for `Channel1` are properly disconnected. Previously `Channel2` would overwrite the connections for `Channel1` causing `Channel1` to never be properly disconnected. There probably is a cleaner way to do this by adding more entries to the function arrays but I took a quick and easy solution.
- Changed the `toggleLED` function so it also accepts true to turn on a LED
- Simplified the scroll and scratch toggle by combining the functions
- Removed a bug that caused scratching to continue as long as the jogwheel was being turned even though the top of the jogwheel was no longer being touched. Apparently the `engine.isScratching` status takes a while to be updated therefor I opted for the use of a custom `Mixage.scratching` parameter.
- Implemented the `script.deckFromGroup(group)` function were applicable.
- Reduced the amount of hardcoded midi controls and moved them to the xml were possible

### XML keybinds

- Added all possible midi commands for the buttons to xml if the midi is currently unbound the `<key>` is empty
- Added comments to each control to make mapping easier
- Changed the order of controls to the order used in the reloop manual. Grouped per channel
- Bound the shift + and - buttons to `beats_translate_earlier` and `beats_translate_later`
- Bound the shift load buttons to `MoveLeft` and `MoveRight`
- The jogwheel and scratch and scroll toggle now also work in shift mode, this is to accommodate the setting of a manual loop in and loop out point
- Bound the master key to `sync_master`, it currently doesn’t actually set the sync master but this will probably handle setting and unsetting the master deck in the future. Because of this I also removed the sync_leader function from the JS
- Added output for LED control of the `beats_translate_earlier` `beats_translate_later` `rate_temp_up` and  `rate_temp_down`

### LEDs

- Added a number of LEDS to the ledmap (`loop`, `fx_sel`, `vu_meter`)
- Added LED output bindings for the +/- buttons (`rate_temp_up/down` and `adjust_beatgrid_up/down`) in the xml
- Added new LED behavior to the FX Select and Loop buttons
  - The FX select button is lit when an effect slot is currently selected for a deck
  - The loop button flashes in time with the beat if a loop is currently active
- Removed `sync_master` from the ledmap to make room for the fx select

### Library

- Split up the large handleLibrary function into smaller separate functions and bind them to the relevant buttons directly
- The library now minimizes/maximizes when the Traxx button is doublepressed (0.4 sec delay)
- Removed the load current track and play function when a load button is pressed in shift mode and bind them to `MoveLeft` and `MoveRight`. This way folders can be opened and closed in the library view
- The automaximize library function remains unchanged

### FX

- Changed the behaviour of most buttons associated with the effects
  - FX on: if no effectunit is currently activated for the deck activates the corresponding effect unit (so `channel1` corresponds to `effectUnit1`). If any `effectUnits` are active for the deck disable them all.
  - FX sel: changes the current selected effectslot for the corresponding effect unit (so `channel1` corresponds to `effectUnit1`)
  - Dry/Wet turn: controls the  `effectUnit` dry/wet mix when no `effectSlot` is selected. Cycles through the effects if an `effectSlot` is selected
  - Dry/Wet press: toggles the selected `effectSlot` on or off, if no slot is selected turns all `effectSlots` in the unit off
  - Dry/wet shift: controls the pan of the master channel (unchanged)
  - Amount: controls the `super1` for the effect unit if no `effectSlot` is selected, if a `effectSlot` is selected controls the `meta` of that slot
- Amount (shift): controls the low/high pass filter for the corresponding channel
- Added soft takeovers for the `meta`, `super1` and `filter` to prevent sudden level jumps when switching between the modes

I'm curious what your thoughts are on these changes. To be honest the list is more extensive than I originally thought. If you have any suggestions or further improvements please let me know. I'll update the manual when the mappings are finalized and merged into the `reloop_mixage` branch.

I'm still thinking of adding a binding on the press of the length button. I suppose clearing any existing loop points is in line with the original control scheme but what do you think. Adding a quantize binding somewhere could also be quite handy but I have yet to find a location that makes sense.

